### PR TITLE
Refactored API calls in frontend to use centralized apiRoutes config

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import NavigationBar from "./ui/NavigationBar";
 import GamePage from "./ui/GamePage";
 import GameCapsuleList from "./GameCapsuleList";
 import Journal from "./ui/Journal"; //Import the dynamic list for users
+import apiRoutes from "./apiRoutes";
 
 function App() {
   const [backendMessage, setBackendMessage] = useState("");
@@ -14,7 +15,7 @@ function App() {
 
   useEffect(() => {
     axios
-      .get("http://localhost:5000/api/test")
+      .get(apiRoutes.getTestConnection)
       .then((response) => setBackendMessage(response.data.message))
       .catch((error) =>
         console.error("COULDNT SIEZE THE BACKEND ARGHHHH", error)

--- a/frontend/src/GameCapsuleList.js
+++ b/frontend/src/GameCapsuleList.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import axios from "axios";
 import GameCapsule from "./ui/GameCapsule"; //formatting for games data
+import apiRoutes from "./apiRoutes";
 
 const GameCapsuleList = ({ searchQuery }) => {
   const { steamid } = useParams();
@@ -16,7 +17,7 @@ const GameCapsuleList = ({ searchQuery }) => {
   useEffect(() => {
     if (!steamid) return;
     axios
-      .get(`http://localhost:5000/api/playersummary/${steamid}`)
+      .get(apiRoutes.getPlayerSummary(steamid))
       .then(({ data }) => {
         // backend sends `personaName`, not `persona_name`
         setPersonaName(data.personaName || steamid);
@@ -35,7 +36,7 @@ const GameCapsuleList = ({ searchQuery }) => {
     setError(null);
 
     axios
-      .get(`http://localhost:5000/api/games/${steamid}`)
+      .get(apiRoutes.getGames(steamid))
       .then((res) => {
         setGames(res.data);
         setLoading(false);

--- a/frontend/src/apiRoutes.js
+++ b/frontend/src/apiRoutes.js
@@ -1,0 +1,15 @@
+const BASE = process.env.REACT_APP_BASE || 'http://localhost:5000/api';
+
+const apiRoutes = {
+    login: `${BASE}/auth/login`,
+    getUser: (steamid) => `${BASE}/users/${steamid}`,
+    getGame: (appid) => `${BASE}/game/${appid}`, //fetch game details
+    getGames: (appid) => `${BASE}/games/${appid}`,
+    getJournalApp: (appid) => `${BASE}/journals?appid=${appid}`,
+    getJournal: `${BASE}/journals`,
+    postJournal: `${BASE}/journals`,
+    getPlayerSummary: (steamid) => `${BASE}/playersummary/${steamid}`,
+    getTestConnection: `${BASE}/test`,
+};
+
+export default apiRoutes;

--- a/frontend/src/ui/GamePage.js
+++ b/frontend/src/ui/GamePage.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import "./GamePage.css";
+import apiRoutes from "../apiRoutes";
 
 const GamePage = () => {
   const { id } = useParams(); // this is your appid
@@ -21,7 +22,7 @@ const GamePage = () => {
   useEffect(() => {
     setLoadingGame(true);
     axios
-      .get(`http://localhost:5000/api/game/${id}`)
+      .get(apiRoutes.getGame(id))
       .then(({ data }) => {
         setGame(data);
         setLoadingGame(false);
@@ -39,7 +40,7 @@ const GamePage = () => {
     setErrorEntries(null);
 
     axios
-      .get(`http://localhost:5000/api/journals?appid=${id}`)
+      .get(apiRoutes.getJournalApp(id))
       .then(({ data }) => {
         setEntries(data);
         setLoadingEntries(false);
@@ -58,7 +59,7 @@ const GamePage = () => {
     setErrorSave(null);
 
     axios
-      .post("http://localhost:5000/api/journals", {
+      .post(apiRoutes.postJournal, {
         appid: id,
         entry: draft.trim(),
       })

--- a/frontend/src/ui/Journal.js
+++ b/frontend/src/ui/Journal.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
 import "./Journal.css";
+import apiRoutes from "../apiRoutes";
 
 const Journal = () => {
   const [entries, setEntries] = useState([]);
@@ -9,7 +10,7 @@ const Journal = () => {
 
   useEffect(() => {
     axios
-      .get("http://localhost:5000/api/journals")
+      .get(apiRoutes.getJournal)
       .then((res) => {
         setEntries(res.data);
         setLoading(false);

--- a/frontend/src/ui/NavigationBar.js
+++ b/frontend/src/ui/NavigationBar.js
@@ -4,6 +4,7 @@ import { Link, useLocation } from "react-router-dom";
 import axios from "axios";
 import Settings from "./Settings";
 import "./NavigationBar.css";
+import apiRoutes from "../apiRoutes";
 
 const NavigationBar = ({ onSearch }) => {
   const location = useLocation();
@@ -32,7 +33,7 @@ const NavigationBar = ({ onSearch }) => {
     if (!savedSteamID) return;
 
     axios
-      .get(`http://localhost:5000/api/playersummary/${savedSteamID}`)
+      .get(apiRoutes.getPlayerSummary(savedSteamID))
       .then((res) => {
         const { avatarFound: af, avatarfull, avatar, personaName } = res.data;
         setAvatarFound(af);


### PR DESCRIPTION
Refactored API calls in frontend to use centralized apiRoutes config. with env support. This replaces hard coded URLs with apiRoutes imports, allowing for the transfer of base URL to be much easier. Resolves #53 Closes #53 